### PR TITLE
Parse SemVer with alphabet characters

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -43,7 +43,8 @@ function findElixirVersion(callback: Function) {
 }
 
 function toLibAndVersion(string: string): string {
-	const match = /\s*"(.*)": {:.*, "([.\d]+)"/g.exec(string);
+	const match = /\s*"(.*)": \{:.*,\s:[^,]*,\s*"([^"]+)/g.exec(string);
+
 	return match ? match.splice(1).join(':') : '';
 }
 


### PR DESCRIPTION
I found this "bug" where it won't list packages with alphabet characters.
And this is part of the [SemVer spec](https://semver.org/#spec-item-9), Hex [validates for SemVer](https://github.com/hexpm/hexpm/blob/57656b506517e5ac6345bee920a0f80d8fb2cc79/lib/hexpm/ecto/version.ex#L14)
I think this "problem" also affect elixir rc versions, I'll take a look later.

Examples
```
  "langchain": {:hex, :langchain, "0.3.0-rc.0", "930d22170fff2c599e8a63a664e437f896555b3cebe3055276bca37e7ae17d1b", [:mix], [{:abacus, "~> 2.1.0", [hex: :abacus, repo: "hexpm", optional: false]}, {:ecto, "~> 3.10", [hex: :ecto, repo: "hexpm", optional: false]}, {:gettext, "~> 0.20", [hex: :gettext, repo: "hexpm", optional: false]}, {:nx, ">= 0.7.0", [hex: :nx, repo: "hexpm", optional: true]}, {:req, ">= 0.5.0", [hex: :req, repo: "hexpm", optional: false]}], "hexpm", "c1f4f563cfddc502d3cfa5180fef154b8e194ef0f6f7bf0fe540761d2439b7ab"},
  "jason": {:hex, :jason, "1.5.0-alpha.2", "42bc9c545bcdf2d5096044449ddcf85235cdbfbaa19792f4a8be581c8f72608e", [:mix], [{:decimal, "~> 1.0 or ~> 2.0", [hex: :decimal, repo: "hexpm", optional: true]}, {:jason_native, ">= 0.0.0", [hex: :jason_native, repo: "hexpm", optional: true]}], "hexpm", "6dcaa0d9fdc22afe9b4d362f17f20844a85f121c50b6e9b9466ac04fe39f3665"},
```

[jason 1.5.0-alpha.2](https://hexdocs.pm/jason/1.5.0-alpha.2/readme.html)
[langchain 0.3.0-rc.0](https://hexdocs.pm/langchain/0.3.0-rc.0/readme.html)
