### PR TITLE
Add Support for elixir release candidate versions

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -35,7 +35,7 @@ function findElixirVersion(callback: Function) {
 	const elixirVersion = spawn('elixir', ['-v']);
 
 	elixirVersion.stdout.on('data', (data: string) => {
-		const match = /Elixir ([0-9]+\.[0-9]+\.[0-9]+)/g.exec(data);
+		const match = /Elixir ([0-9]+\.[0-9]+\.[0-9]+(?:-rc\.?[0-9]+)?)/g.exec(data);
 		const version = match ? `elixir:${match.splice(1)}` : '';
 
 		callback(version);


### PR DESCRIPTION
Adding support for release candidate versions of elixir.
A quick way to get all of them `asdf list-all elixir | grep -v "otp\|master\|main"`.
From hexdocs elixir adopted the pattern of VERSION-rc.NUMBER.
The only ofender is the 1.0.0 RCs that didn't had adopted the **dot**.

This update cover it all.

```js
const elixirVersion = (data) => {
	const match = /Elixir ([0-9]+\.[0-9]+\.[0-9]+(?:-rc\.?[0-9]+)?)/g.exec(data);
	return (match ? `elixir:${match.splice(1)}` : '');
};


const t1 = "Elixir 1.17.0-rc.1 (ac64fba) (compiled with Erlang/OTP 27)"
console.log(elixirVersion(t1)); // Output: "elixir:1.17.0-rc.1"

const t2 = "Elixir 1.12.2 (compiled with Erlang/OTP 24)"
console.log(elixirVersion(t2)); // Output: "elixir:1.12.2"

const t3 = "Elixir 1.0.0-rc1"
console.log(elixirVersion(t3)); // Output: "elixir:1.0.0-rc1"

const t4 = "Elixir fdsafdsa"
console.log(elixirVersion(t4)); // Output:
```

The `1.0.0-rc1` example don't have the "compiled with" text because at the time the command `-v` only [printed the version](https://github.com/elixir-lang/elixir/blob/5b4497fa6b2da7831418cf1307248dc73b4ee34b/lib/elixir/lib/kernel/cli.ex#L137) and not the [full build info](https://github.com/elixir-lang/elixir/blob/00f26629daa66a51efa050c51e8c5ca1ab62eeca/lib/elixir/lib/kernel/cli.ex#L245) at the time.

There is one case not supported right now which is if you are running bleeding edge elixir `main` branch. The `-v` will return `1.18.0-dev` and which is a HexDoc 404, in this case we should use the version `main` which pull the latest main branch doc. We can do this later.